### PR TITLE
fix: removing of k0sworker systemd

### DIFF
--- a/roles/reset/tasks/main.yml
+++ b/roles/reset/tasks/main.yml
@@ -29,6 +29,7 @@
     - "{{ k0s_libexec_dir }}"
     - /var/lib/kubelet
     - "{{ systemd_dest }}/k0scontroller.service"
+    - "{{ systemd_dest }}/k0sworker.service"
 
 - name: daemon_reload
   systemd:


### PR DESCRIPTION
The reset functionality doesn't clean up the k0sworker. Hence failing the reinstallation of the k0s.